### PR TITLE
Fixed Router init method and changed FUNC_VIEW type location

### DIFF
--- a/src/django_routify/_abstraction.py
+++ b/src/django_routify/_abstraction.py
@@ -1,6 +1,10 @@
+from django.http import HttpRequest, HttpResponse
 from django.urls import path
 
 from abc import ABC, abstractmethod
+from typing import Callable, Type
+
+FUNC_VIEW: Type = Callable[[HttpRequest, ...], HttpResponse]
 
 
 class RouterAbstraction(ABC):
@@ -31,7 +35,7 @@ class RouterAbstraction(ABC):
     @abstractmethod
     def __init__(
             self,
-            prefix: str,
+            prefix: str = None,
             app_name: str = None,
             auto_naming: bool = True,
             auto_trailing_slash: bool = False,
@@ -43,7 +47,10 @@ class RouterAbstraction(ABC):
             :param auto_naming: bool
             :param auto_trailing_slash: bool
         '''
-        ...
+        raise NotImplementedError(
+            'Use Router from django_routify, '
+            'but not RouterAbstraction'
+        )
 
     @property
     @abstractmethod

--- a/src/django_routify/router.py
+++ b/src/django_routify/router.py
@@ -1,12 +1,10 @@
 from inspect import isclass
-from typing import Callable, Type
 import re
 
-from django.http import HttpRequest, HttpResponse
 from django.urls import path
 from django.views import View
 
-from ._abstraction import RouterAbstraction
+from ._abstraction import RouterAbstraction, FUNC_VIEW
 
 
 class Router(RouterAbstraction):
@@ -28,12 +26,16 @@ class Router(RouterAbstraction):
             auto_naming: bool = True,
             auto_trailing_slash: bool = False,
     ) -> None:
-        self.__prefix = prefix.rstrip('/').lstrip('/') or ''
-        if self.__prefix != '':
-            self.__prefix += '/'
+        prefix = prefix or ''
+
+        self.__prefix = prefix.rstrip('/').lstrip('/') + '/'
+        if self.__prefix == '/':
+            self.__prefix = ''
+
         self.__app_name = app_name or ''
         self.__auto_naming = auto_naming
         self.__auto_trailing_slash = auto_trailing_slash
+
         self.__urls = []
 
     @property
@@ -57,8 +59,6 @@ class Router(RouterAbstraction):
         return self.__urls
 
     def route(self, url_path: str, name: str = None):
-        FUNC_VIEW: Type = Callable[[HttpRequest, ...], HttpResponse]
-
         def register(view: FUNC_VIEW | View) -> FUNC_VIEW | View:
             nonlocal url_path, name
 


### PR DESCRIPTION
Fixed bug in Router init method with prefix.
Moved FUNC_VIEW type, as a constant annotation, in _abstract file.