### PR TITLE
Requirements and Router string representation update

### DIFF
--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -1,4 +1,4 @@
-name: Django-Routify Beta v0.2.1
+name: Django-Routify Beta v0.2.2
 
 on:
   release:
@@ -16,9 +16,9 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Set up Python
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v5
       with:
-        python-version: '3.10'
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
 
     - name: Install dependencies
       run: |
@@ -36,7 +36,7 @@ jobs:
         password: ${{ secrets.PYPI_API_TOKEN }}
 
     - name: Upload build artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: dist-files
         path: dist/*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,11 +5,11 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "django-routify"
-version = "0.2.1"
+version = "0.2.2"
 description = "Django-Routify is a package for simple routing Views in the classic Django framework."
 
 readme = "README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.8"
 
 license = {file = "LICENSE"}
 
@@ -39,6 +39,8 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
 
     "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
@@ -46,7 +48,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "django>5.0"
+    "django>4.0"
 ]
 
 [project.urls]

--- a/src/django_routify/_abstraction.py
+++ b/src/django_routify/_abstraction.py
@@ -111,3 +111,19 @@ class RouterAbstraction(ABC):
             :return: Any
         '''
         ...
+
+    @abstractmethod
+    def __str__(self) -> str:
+        '''
+            Router string representation
+            :return: str
+        '''
+        ...
+
+    @abstractmethod
+    def __repr__(self) -> str:
+        '''
+            Router string representation
+            :return: str
+        '''
+        ...

--- a/src/django_routify/router.py
+++ b/src/django_routify/router.py
@@ -94,3 +94,13 @@ class Router(RouterAbstraction):
 
             return view
         return register
+
+    def __str__(self) -> str:
+        return f'Router(\n' \
+               f'\tapp_name:\t"{self.__app_name}"\n' \
+               f'\turl_prefix:\t"{self.__prefix}"\n' \
+               f'\turls:\t\t{self.__urls}\n' \
+               f')'
+
+    def __repr__(self) -> str:
+        return str(self)


### PR DESCRIPTION
Now Python >= 3.8 and Django >= 4.0 is available to use this package
Also now you can print your router and check what it's look like